### PR TITLE
商品詳細機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :move_to_index, except: [:index]
+  before_action :move_to_index, except: [:index, :show]
 
   def index
     @items = Item.includes(:user).order('created_at ASC')
@@ -17,6 +17,10 @@ class ItemsController < ApplicationController
     else
       render :new
     end
+  end
+
+  def show
+    @item = Item.find(params[:id])
   end
 
   private

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,7 +128,7 @@
 
     <% @items.each do |item|%>
       <li class='list'>
-        <%= link_to item_path(item.id), method: :get  do %>
+        <%= link_to item_path( item.id ), method: :get  do %>
         <div class='item-img-content'>
           <%= image_tag item.image , class: "item-img" if item.image.attached? %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,18 +8,18 @@
     </h2>
     <div class='item-img-content'>
 
-      <%#ここです！0907%>
-      <%#= image_tag @item.item_image ,class:"item-box-img" %>
+
+      <%= image_tag @item.image ,class:"item-box-img" %>
 
 
       <%# 商品が売れている場合は、sold outの表示をしましょう。 %>
-      <% if @exchange.exists?(item_id: @item.id)%>
+      <%# if @exchange.exists?(item_id: @item.id)%>
       <div class='sold-out'>
         <span>Sold Out!!</span>
       </div>
-      <% else %>
+      <%# else %>
       
-      <% end %>
+      <%# end %>
       <%# //商品が売れている場合は、sold outの表示をしましょう。 %>
     </div>
     <div class="item-price-box">
@@ -31,49 +31,44 @@
       </span>
     </div>
 
-    <%# ログインしているユーザと出品しているユーザが同一人物である時、商品の編集と削除を表示にしましょう%>
-    <% if current_user.id == @item.user_id %>
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-    <% end %>
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <% if @exchange.exists?(item_id: @item.id)%>
-    <% else %>
-    <%= link_to '購入画面に進む', exchanges_index_path(@item.id) ,class:"item-red-btn"%>
-    <% end %>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
 
-    <%# // ログインしているユーザと出品しているユーザが同一人物である時、商品の編集と削除を表示にしましょう %>
+    <% if user_signed_in? && current_user.id == @item.user_id %>
+      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <% elsif user_signed_in?  %>
+    <%# if @exchange.exists?(item_id: @item.id)%>
+      <%= link_to '購入画面に進む', exchanges_index_path(@item.id) ,class:"item-red-btn"%>
+    <% end %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.introduction %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= @user.nickname %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= @category.category %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= @condition.condition %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= @delivery_burden.delivery_burden %></td>
+          <td class="detail-value"><%= @item.delivery_burden.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= @prefecture.prefecture %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= @prepare_day.prepare_day %></td>
+          <td class="detail-value"><%= @item.prepare_day.name %></td>
         </tr>
       </tbody>
     </table>
@@ -112,7 +107,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>


### PR DESCRIPTION
### What（どのような実装をしているのか)
一覧ページから商品の詳細にいけ、出品者は編集や削除/ログインユーザーは購入といったことをするための実装
ログインしていないユーザーでも詳細へ遷移できるが購入はできない実装
### Why（なぜこの実装が必要なのか）
フリマアプリの醍醐味商品の売買をするための実装
商品の詳細を見ることができるようにする
### gyazo url　↓
・ログアウト状態でも詳細ページへいける（購入はできない）
https://gyazo.com/9a18f504337f85f61ac83f88cd7144a3
・出品者が出した商品ページ（編集・削除）
https://gyazo.com/1884986a43f8c0d29683099e3b3fc09a
・出品者以外のログインユーザーのみ商品の購入ができる
https://gyazo.com/c62749e44ae0b00eb41dd273754deaa4
・商品詳細の画像
https://gyazo.com/bcbf8f4f6b069c530cc4a43cdef55c80